### PR TITLE
chore(powerbi-client): powerbi client should be reset for each view mode

### DIFF
--- a/app/components/app/index.jsx
+++ b/app/components/app/index.jsx
@@ -13,4 +13,3 @@ const App = () => (
 );
 
 export default App;
-

--- a/app/components/radioBtn/index.jsx
+++ b/app/components/radioBtn/index.jsx
@@ -1,16 +1,30 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
 import './index.scss';
 
-const RadioBtn = ({text, id, value, changeHandler}) => {
+const RadioBtn = ({ text, value, changeHandler, active }) => {
     const handleChangeEvent = () => changeHandler(value)
 
     return (
         <span className="radioBtn">
-            <label className="radioBtn_label" htmlFor={id}>{`${text} mode`}</label>
-            <input className="radioBtn_input" name="select" id={id} onChange={handleChangeEvent} type="radio" value={value} />
+            <label className="radioBtn_label">{`${text} mode`}</label>
+            <input
+                className="radioBtn_input"
+                name="select"
+                checked={active}
+                onChange={handleChangeEvent}
+                type="radio" value={value}
+            />
         </span>
     );
-}
+};
+
+RadioBtn.propTypes = {
+    text: PropTypes.string.isRequired,
+    value: PropTypes.string.isRequired,
+    active: PropTypes.bool.isRequired,
+    changeHandler: PropTypes.func.isRequired
+};
 
 export default RadioBtn;

--- a/app/components/report/index.jsx
+++ b/app/components/report/index.jsx
@@ -11,17 +11,35 @@ import './index.scss';
 
 const Report = () => {
     const [viewMode, setViewMode] = useState('view');
-    const [ reportResponse, setReportResponse ] = useState({
+    const [reportResponse, setReportResponse] = useState({
         reportId: "",
         embedToken: "",
         embedUrl: ""
     });
+    const [radioBtnState, setRadioBtnState] = useState({
+        view: true,
+        edit: false,
+        create: false
+    });
+    
 
     const bucket = React.createRef();
-    const radioArray = ['create', 'view', 'edit'];
+    const { view, edit, create } = radioBtnState;
+
+    const radioArray = [
+        { name: 'view', active: view },
+        { name: 'edit', active: edit },
+        { name: 'create', active: create },
+    ];
 
     const getReportEmbedType = (embedType) => {
         setViewMode(embedType);
+        setRadioBtnState({
+            view: false,
+            edit: false,
+            create: false,
+            [embedType]: true
+        });
     };
 
     const renderReport = (reportId, embedToken, embedUrl) => {
@@ -45,7 +63,7 @@ const Report = () => {
             }).then(response => response.json())
 
             setReportResponse({
-                reportId:  response.ReportId,
+                reportId: response.ReportId,
                 embedToken: response.EmbedToken,
                 embedUrl: response.EmbedUrl
             });
@@ -55,14 +73,15 @@ const Report = () => {
     };
 
     useEffect(() => {
-        const url = 'https://pbifunc2.azurewebsites.net/api/HttpTriggerCSharp1?code=dl9o4wFwwLKuJubIrukK0Gg9vd6JVStRiuUQiS6/lta1aLhNVW55cA==';
+        const url = '';
         getUrl(url);
     }, []);
 
     useEffect(() => {
-        const {reportId, embedToken, embedUrl} = reportResponse;
+        powerbi.reset(bucket.current);
+        const { reportId, embedToken, embedUrl } = reportResponse;
 
-        if(reportId) renderReport(reportId, embedToken, embedUrl);
+        if (reportId) renderReport(reportId, embedToken, embedUrl);
     }, [reportResponse, viewMode]);
 
     return (

--- a/app/components/reportToggle/index.jsx
+++ b/app/components/reportToggle/index.jsx
@@ -1,14 +1,15 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
 import RadioBtn from '../radioBtn/index.jsx';
 
 const ReportToggle = ({ radioBtnArray, radioBtnOnChange}) => {
-    console.log(radioBtnArray);
-    const radioBtns = radioBtnArray.map((item) => {
+    const radioBtns = radioBtnArray.map(({ name, active}) => {
         return <RadioBtn
-            text={item}
-            value={item}
-            key={item}
+            text={name}
+            value={name}
+            key={name}
+            active={active}
             changeHandler={radioBtnOnChange}
         />
     });
@@ -18,6 +19,11 @@ const ReportToggle = ({ radioBtnArray, radioBtnOnChange}) => {
             {radioBtns}
         </form>
     );
+};
+
+ReportToggle.propTypes = {
+    radioBtnArray: PropTypes.array.isRequired,
+    radioBtnOnChange: PropTypes.func.isRequired
 };
 
 export default ReportToggle;

--- a/app/utility/config.js
+++ b/app/utility/config.js
@@ -10,7 +10,7 @@ export default (
             tokenType: pbiInstance.models.TokenType.Embed,
             accessToken,
             embedUrl,
-            datasetId: 'e5bcb264-794e-4ae4-ad55-dd7c7967673b'
+            datasetId: ''
         },
         edit: {
             type: 'report',

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
   "dependencies": {
     "fetch-jsonp": "^1.1.3",
     "powerbi-client": "^2.11.0",
+    "prop-types": "^15.7.2",
     "react": "^16.13.0",
     "react-dom": "^16.13.0",
     "react-router-dom": "^5.1.2",


### PR DESCRIPTION

#### What does this PR do?
This pull request ensures that the default view is the view radion button and is selected on load
#### Description of Task to be completed
- install prop-types
- add proptype validation
- add powerbi reset
- ensure default radio button is the view button
#### How should this be manually tested?

#### Any Background Context You want to provide?

#### What are the relevant pivotal tracker stories?

[#story-id](https://pivotaltracker.com/story/show/story-id)

#### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/42284402/77261181-e34b5980-6c49-11ea-9170-a5f309600463.png)

#### Questions:
